### PR TITLE
Added additional compatibility check for getbufinfo()

### DIFF
--- a/plugin/factorus.vim
+++ b/plugin/factorus.vim
@@ -70,7 +70,7 @@ if &cp || exists('g:loaded_factorus')
     finish
 endif
 
-if v:version < 700
+if v:version < 700 || !has('patch-7.4.2204')
     echohl WarningMsg
     echom 'Factorus: Vim version is too old, please upgrade to 7.0 or later.'
     echohl None


### PR DESCRIPTION
This should help to prevent issues like in #10 , by first checking to make sure getbufinfo() is part of the user's vim installation.